### PR TITLE
Fixed casting warning

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -72,7 +72,7 @@ FILE* cfg_logfile_handle;
 bool cfg_quiet;
 std::string cfg_options_str;
 bool cfg_benchmark;
-int cfg_fastmove_cnt;
+size_t cfg_fastmove_cnt;
 
 void GTP::setup_default_parameters() {
     cfg_gtp_mode = false;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -55,7 +55,7 @@ extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
 extern std::string cfg_options_str;
 extern bool cfg_benchmark;
-extern int cfg_fastmove_cnt;
+extern size_t cfg_fastmove_cnt;
 
 /*
     A list of all valid GTP2 commands is defined here:

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -283,7 +283,7 @@ static void parse_commandline(int argc, char *argv[]) {
     }
 
     if (vm.count("fastmove")) {
-        cfg_fastmove_cnt = vm["fastmove"].as<int>();
+        cfg_fastmove_cnt = (size_t)std::max(0, vm["fastmove"].as<int>());
     }
 
     auto out = std::stringstream{};


### PR DESCRIPTION
Minor change to fix a warning about comparison between signed and unsigned values.